### PR TITLE
fixed force close error

### DIFF
--- a/websocket_server/websocket_server.py
+++ b/websocket_server/websocket_server.py
@@ -157,8 +157,10 @@ class WebSocketHandler(StreamRequestHandler):
 			return bytes
 
 	def read_next_message(self):
-
-		b1, b2 = self.read_bytes(2)
+		try:
+			b1, b2 = self.read_bytes(2)
+		except ValueError as e:
+			b1, b2 = 0, 0
 
 		fin    = b1 & FIN
 		opcode = b1 & OPCODE


### PR DESCRIPTION
When a client force close(such as CTRL+C), websocket server will show error because can't get next message.