### PR TITLE
Fixed message validation for Python 3

### DIFF
--- a/websocket_server/websocket_server.py
+++ b/websocket_server/websocket_server.py
@@ -257,7 +257,9 @@ class WebSocketHandler(StreamRequestHandler):
             if not message:
                 logger.warning("Can\'t send message, message is not valid UTF-8")
                 return False
-        elif isinstance(message, str) or isinstance(message, unicode):
+        elif sys.version_info < (3,0) and (isinstance(message, str) or isinstance(message, unicode)):
+            pass
+        elif isinstance(message, str):
             pass
         else:
             logger.warning('Can\'t send message, message has to be a string or bytes. Given type is %s' % type(message))


### PR DESCRIPTION
Added short-circuit that prevents checking if message is `unicode`, if Python version is 3.0 or higher. There is no `unicode` keyword in Python 3 since all strings are sequences of Unicode characters.

Discovered this when trying to pass a `msg` of type `dict` to  `send_message(self, client, msg)`. Results in `NameError: name 'unicode' is not defined` when using Python 3.6.1.