### PR TITLE
handshake(): work with TCP health check

### DIFF
--- a/websocket_server/websocket_server.py
+++ b/websocket_server/websocket_server.py
@@ -293,8 +293,12 @@ class WebSocketHandler(StreamRequestHandler):
         self.request.send(header + payload)
 
     def handshake(self):
-        message = self.request.recv(1024).decode().strip()
-        upgrade = re.search('\nupgrade[\s]*:[\s]*websocket', message.lower())
+        try:
+            message = self.request.recv(1024).decode().strip()
+        except Exception as e:
+            self.keep_alive = False
+            return
+	upgrade = re.search('\nupgrade[\s]*:[\s]*websocket', message.lower())
         if not upgrade:
             self.keep_alive = False
             return

--- a/websocket_server/websocket_server.py
+++ b/websocket_server/websocket_server.py
@@ -298,7 +298,7 @@ class WebSocketHandler(StreamRequestHandler):
         except Exception as e:
             self.keep_alive = False
             return
-	upgrade = re.search('\nupgrade[\s]*:[\s]*websocket', message.lower())
+        upgrade = re.search('\nupgrade[\s]*:[\s]*websocket', message.lower())
         if not upgrade:
             self.keep_alive = False
             return


### PR DESCRIPTION
With the websocket server deployed after SLB, the health check feature of the SLB connects to the port and then closes the connection without sending any data.