### PR TITLE
python 2.7 crashes handling error ConnectionResetError

### DIFF
--- a/websocket_server/websocket_server.py
+++ b/websocket_server/websocket_server.py
@@ -6,6 +6,8 @@ import struct
 from base64 import b64encode
 from hashlib import sha1
 import logging
+from socket import error as SocketError
+import errno
 
 if sys.version_info[0] < 3:
     from SocketServer import ThreadingMixIn, TCPServer, StreamRequestHandler
@@ -189,10 +191,13 @@ class WebSocketHandler(StreamRequestHandler):
     def read_next_message(self):
         try:
             b1, b2 = self.read_bytes(2)
-        except ConnectionResetError:
-            logger.info("Client closed connection.")
-            self.keep_alive = 0
-            return
+        except SocketError as e:
+            if e.errno == errno.ECONNRESET:
+                logger.info("Client closed connection.")
+                print("Error: {}".format(e))
+                self.keep_alive = 0
+                return
+            b1, b2 = 0, 0
         except ValueError as e:
             b1, b2 = 0, 0
 


### PR DESCRIPTION
Hi! I was running the server in python 2.7 but it crashed when it tried to handle the *ConnectionResetError*, because I think it is not defined in python 2.7. I'm proposing this fix, although I dont know if there's a better way to do it.