### PR TITLE
 Abort connection based on origin header

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,22 +69,24 @@ The WebsocketServer can be initialized with the below parameters.
 
 ### Methods
 
-| Method                      | Description                                                                           | Takes           | Gives |
-|-----------------------------|---------------------------------------------------------------------------------------|-----------------|-------|
-| `set_fn_new_client()`       | Sets a callback function that will be called for every new `client` connecting to us  | function        | None  |
-| `set_fn_client_left()`      | Sets a callback function that will be called for every `client` disconnecting from us | function        | None  |
-| `set_fn_message_received()` | Sets a callback function that will be called when a `client` sends a message          | function        | None  |
-| `send_message()`            | Sends a `message` to a specific `client`. The message is a simple string.             | client, message | None  |
-| `send_message_to_all()`     | Sends a `message` to **all** connected clients. The message is a simple string.       | message         | None  |
+| Method                      | Description                                                                                    | Takes           | Gives |
+|-----------------------------|------------------------------------------------------------------------------------------------|-----------------|-------|
+| `set_fn_new_client()`       | Sets a callback function that will be called for every new `client` connecting to us           | function        | None    |
+| `set_fn_client_left()`      | Sets a callback function that will be called for every `client` disconnecting from us          | function        | None    |
+| `set_fn_message_received()` | Sets a callback function that will be called when a `client` sends a message                   | function        | None    |
+| `set_fn_allow_connection()` | Sets a handler function that will be called to determine whether or not to accept a connection | origin                 | Boolean |
+| `send_message()`            | Sends a `message` to a specific `client`. The message is a simple string.                      | client, message         | None    |
+| `send_message_to_all()`     | Sends a `message` to **all** connected clients. The message is a simple string.                | message                 | None    |
 
 
 ### Callback functions
 
-| Set by                      | Description                                       | Parameters              |
-|-----------------------------|---------------------------------------------------|-------------------------|
-| `set_fn_new_client()`       | Called for every new `client` connecting to us    | client, server          |
-| `set_fn_client_left()`      | Called for every `client` disconnecting from us   | client, server          |
-| `set_fn_message_received()` | Called when a `client` sends a `message`          | client, server, message |
+| Set by                      | Description                                         | Parameters              |
+|-----------------------------|-----------------------------------------------------|-------------------------|
+| `set_fn_new_client()`       | Called for every new `client` connecting to us      | client, server          |
+| `set_fn_client_left()`      | Called for every `client` disconnecting from us     | client, server          |
+| `set_fn_message_received()` | Called when a `client` sends a `message`            | client, server, message |
+| `set_fn_allow_connection()` | Called when a connection from `origin` is initiated | origin                  |
 
 
 The client passed to the callback is the client that left, sent the message, etc. The server might not have any use to use. However it is passed in case you want to send messages to clients.


### PR DESCRIPTION
[RFC 6455](https://tools.ietf.org/html/rfc6455#section-10) specifies that a handshake may be aborted by the server based on the origin header.

This PR adds another handler function which gets called when a handshake has been initiated. 

- The handler is called with the value of the `origin` header or `None` and returns a `Boolean`.
- In case a falsy value is returned from the handler, the handshake is aborted with a `403 Forbidden` response.