### PR TITLE
Remove last print statement

### DIFF
--- a/websocket_server/websocket_server.py
+++ b/websocket_server/websocket_server.py
@@ -194,7 +194,6 @@ class WebSocketHandler(StreamRequestHandler):
         except SocketError as e:  # to be replaced with ConnectionResetError for py3
             if e.errno == errno.ECONNRESET:
                 logger.info("Client closed connection.")
-                print("Error: {}".format(e))
                 self.keep_alive = 0
                 return
             b1, b2 = 0, 0


### PR DESCRIPTION
It's nice to have the ability to explicity control the way messages are sent to stdout, and this seems to be the last print statement in the way of getting there.

I didn't replace it with a `logger` message since it seemed to be a fairly nominal state of operating (clients are allowed to unexpectedly close the connection, no need to report an error here).