### PR TITLE
Add minimum python version in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,4 +53,5 @@ setup(
     cmdclass={
         'verify': VerifyVersionCommand,
     },
+    python_requires=">=3.6",
 )


### PR DESCRIPTION
It looks like latest released version don't support Python 3.5 anymore. It is
failing on line
https://github.com/Pithikos/python-websocket-server/blob/master/websocket_server/websocket_server.py#L296
because it is using a f-string which is only available in Python 3.6+.

If it was intentional, this PR is adding the correct package metadata so pip
can choose the right version depending on the user Python Version.