### PR TITLE
Add PUB/SUB functionality to add categories

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,15 +75,16 @@ The WebsocketServer can be initialized with the below parameters.
 | Method                      | Description                                                                                  | Takes           | Gives |
 |-----------------------------|----------------------------------------------------------------------------------------------|-----------------|-------|
 | `run_forever()`             | Runs server until shutdown_gracefully or shutdown_abruptly are called.  | threaded: run server on its own thread if True        | None  |
-| `set_fn_new_client()`       | Sets a callback function that will be called for every new `client` connecting to us         | function        | None  |
-| `set_fn_client_left()`      | Sets a callback function that will be called for every `client` disconnecting from us        | function        | None  |
-| `set_fn_message_received()` | Sets a callback function that will be called when a `client` sends a message                 | function        | None  |
-| `set_fn_client_subbed()`    | Sets a callback function that will be called for every `client` subscribing to a service     | function        | None  |
-| `set_fn_client_unsubbed()`  | Sets a callback function that will be called for every `client` unsubscribing to a service   | function        | None  |
-| `send_message()`            | Sends a `message` to a specific `client`. The message is a simple string.                    | client, message | None  |
-| `send_message_to_all()`     | Sends a `message` to **all** connected clients. The message is a simple string.              | message         | None  |
-| `shutdown_gracefully()`     | Shutdown server by sending a websocket CLOSE handshake to all connected clients.             | None            | None  |
-| `shutdown_abruptly()`       | Shutdown server without sending any websocket CLOSE handshake.                               | None            | None  |
+| `set_fn_new_client()`       | Sets a callback function that will be called for every new `client` connecting to us                   | function        | None  |
+| `set_fn_client_left()`      | Sets a callback function that will be called for every `client` disconnecting from us                  | function        | None  |
+| `set_fn_message_received()` | Sets a callback function that will be called when a `client` sends a message                           | function        | None  |
+| `set_fn_client_subbed()`    | Sets a callback function that will be called for every `client` subscribing to a service               | function        | None  |
+| `set_fn_client_unsubbed()`  | Sets a callback function that will be called for every `client` unsubscribing to a service             | function        | None  |
+| `send_message()`            | Sends a `message` to a specific `client`. The message is a simple string.                              | client, message | None  |
+| `send_message_to_all()`     | Sends a `message` to **all** connected clients. The message is a simple string.                        | message         | None  |
+| `publish()`                 | Publishes `message` to to the specified service (all its subscribers) This message is a simple string. | service, message| None  |
+| `shutdown_gracefully()`     | Shutdown server by sending a websocket CLOSE handshake to all connected clients.                       | None            | None  |
+| `shutdown_abruptly()`       | Shutdown server without sending any websocket CLOSE handshake.                                         | None            | None  |
 
 
 

--- a/README.md
+++ b/README.md
@@ -64,33 +64,38 @@ The WebsocketServer can be initialized with the below parameters.
 
 ### Properties
 
-| Property | Description          |
-|----------|----------------------|
-| clients  | A list of `client`   |
+| Property       | Description                                                         |
+|----------------|---------------------------------------------------------------------|
+| clients        | A list of `client`                                                  |
+| subscriptions  | A dict of services, with each service containing a list of `client` |
 
 
 ### Methods
 
-| Method                      | Description                                                                           | Takes           | Gives |
-|-----------------------------|---------------------------------------------------------------------------------------|-----------------|-------|
-| `run_forever()`       | Runs server until shutdown_gracefully or shutdown_abruptly are called.  | threaded: run server on its own thread if True        | None  |
-| `set_fn_new_client()`       | Sets a callback function that will be called for every new `client` connecting to us  | function        | None  |
-| `set_fn_client_left()`      | Sets a callback function that will be called for every `client` disconnecting from us | function        | None  |
-| `set_fn_message_received()` | Sets a callback function that will be called when a `client` sends a message          | function        | None  |
-| `send_message()`            | Sends a `message` to a specific `client`. The message is a simple string.             | client, message | None  |
-| `send_message_to_all()`     | Sends a `message` to **all** connected clients. The message is a simple string.       | message         | None  |
-| `shutdown_gracefully()`     | Shutdown server by sending a websocket CLOSE handshake to all connected clients.      | None            | None  |
-| `shutdown_abruptly()`       | Shutdown server without sending any websocket CLOSE handshake.                        | None            | None  |
+| Method                      | Description                                                                                  | Takes           | Gives |
+|-----------------------------|----------------------------------------------------------------------------------------------|-----------------|-------|
+| `run_forever()`             | Runs server until shutdown_gracefully or shutdown_abruptly are called.  | threaded: run server on its own thread if True        | None  |
+| `set_fn_new_client()`       | Sets a callback function that will be called for every new `client` connecting to us         | function        | None  |
+| `set_fn_client_left()`      | Sets a callback function that will be called for every `client` disconnecting from us        | function        | None  |
+| `set_fn_message_received()` | Sets a callback function that will be called when a `client` sends a message                 | function        | None  |
+| `set_fn_client_subbed()`    | Sets a callback function that will be called for every `client` subscribing to a service     | function        | None  |
+| `set_fn_client_unsubbed()`  | Sets a callback function that will be called for every `client` unsubscribing to a service   | function        | None  |
+| `send_message()`            | Sends a `message` to a specific `client`. The message is a simple string.                    | client, message | None  |
+| `send_message_to_all()`     | Sends a `message` to **all** connected clients. The message is a simple string.              | message         | None  |
+| `shutdown_gracefully()`     | Shutdown server by sending a websocket CLOSE handshake to all connected clients.             | None            | None  |
+| `shutdown_abruptly()`       | Shutdown server without sending any websocket CLOSE handshake.                               | None            | None  |
 
 
 
 ### Callback functions
 
-| Set by                      | Description                                       | Parameters              |
-|-----------------------------|---------------------------------------------------|-------------------------|
-| `set_fn_new_client()`       | Called for every new `client` connecting to us    | client, server          |
-| `set_fn_client_left()`      | Called for every `client` disconnecting from us   | client, server          |
-| `set_fn_message_received()` | Called when a `client` sends a `message`          | client, server, message |
+| Set by                      | Description                                                 | Parameters              |
+|-----------------------------|-------------------------------------------------------------|-------------------------|
+| `set_fn_new_client()`       | Called for every new `client` connecting to us              | client, server          |
+| `set_fn_client_left()`      | Called for every `client` disconnecting from us             | client, server          |
+| `set_fn_client_subbed()`    | Called for every new `client` subscribing to a service      | client, server, service |
+| `set_fn_client_unsubbed()`  | Called for every new `client` unsubscribing to a service    | client, server, service |
+| `set_fn_message_received()` | Called when a `client` sends a `message`                    | client, server, message |
 
 
 The client passed to the callback is the client that left, sent the message, etc. The server might not have any use to use. However it is passed in case you want to send messages to clients.

--- a/websocket_server/websocket_server.py
+++ b/websocket_server/websocket_server.py
@@ -218,7 +218,6 @@ class WebsocketServer(ThreadingMixIn, TCPServer, API):
             pass
         
     def _unicast(self, receiver_client, msg):
-        logger.info(f"sending to {receiver_client['id']}")
         receiver_client['handler'].send_message(msg)
 
     def _multicast(self, msg):

--- a/websocket_server/websocket_server.py
+++ b/websocket_server/websocket_server.py
@@ -174,8 +174,8 @@ class WebsocketServer(ThreadingMixIn, TCPServer, API):
                 self._client_unsub(self.handler_to_client(handler), json_message["unsubscribe"])
                 return
 
-        except Exception as e:
-            logger.warn(e)
+        except:
+            pass
 
         self.message_received(self.handler_to_client(handler), self, msg)
 


### PR DESCRIPTION
I have been using this for a while now but realized I see no way to separate clients so I can send specific info to some of them and not to others, without doing so manually. So I added the ability for clients to "subscribe" to a specific service by sending this to the server: `{"subscribe": "service_name"}` and unsubscribe by using `{"unsubscribe": "service_name"}`. The server can then send info to only those subscribed to the service by using `server.publish("service_name", "you guys are the VIPs")`

This also adds event functions for every time a client subscribes or unsubscribes, as well as an easy-to-access object containing all the services and their subscribers.

This is my first time contributing to an open-source project so I am sorry for anything dumb I might have done.