### PR TITLE
Call disconnect callback after client removal

### DIFF
--- a/websocket_server/websocket_server.py
+++ b/websocket_server/websocket_server.py
@@ -187,9 +187,9 @@ class WebsocketServer(ThreadingMixIn, TCPServer, API):
 
     def _client_left_(self, handler):
         client = self.handler_to_client(handler)
-        self.client_left(client, self)
         if client in self.clients:
             self.clients.remove(client)
+        self.client_left(client, self)
 
     def _unicast(self, receiver_client, msg):
         receiver_client['handler'].send_message(msg)


### PR DESCRIPTION
**Call the `self.client_left()` disconnect callback after removing the client from the `self.clients` list.**

When a client disconnects, it first removes the client from the `self.clients` list, and only then calls the `self.client_left()` callback to make sure the program doesn't get false data. Just like when a new client connects: first it adds the client to the `self.clients` list and only then calls the `self.new_client` callback.

This change makes the connection/disconnection callbacks more reliable and consistent.